### PR TITLE
Handle directory of . / extra log messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,8 +26,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	start := args[0]
-	processItem(start)
+	for _, arg := range args {
+		processItem(arg)
+	}
 }
 
 func processItem(fn string) {

--- a/main.go
+++ b/main.go
@@ -27,6 +27,10 @@ func main() {
 	}
 
 	for _, arg := range args {
+		if arg == "." {
+			processDir(".")
+			continue
+		}
 		processItem(arg)
 	}
 }
@@ -90,6 +94,7 @@ func processFile(fn string, mode os.FileMode) {
 	newSrc := f.Bytes()
 	if bytes.Equal(newSrc, src) {
 		// No changes
+		log.Printf("No changes required: %s", fn)
 		return
 	}
 
@@ -100,7 +105,7 @@ func processFile(fn string, mode os.FileMode) {
 		log.Printf("WARNING: File %q may be left with only partial content", fn)
 		return
 	}
-	log.Printf("Made changes to %s", fn)
+	log.Printf("Made changes: %s", fn)
 }
 
 func cleanFile(f *hclwrite.File) {


### PR DESCRIPTION
* Added the ability to handle multiple command line arguments
* It wasn't obvious why `terraform-clean-syntax .` didn't work (it's because you look for a directory prefix of . and skip it). So I made that work.
* I also logged when files weren't updated - might be a bit noisy - I added it while trying to workout why cleaning `.` didn't work.

Feel free to adjust / drop this PR!