### PR TITLE
Recover HCL parsing errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -74,6 +75,12 @@ func processFile(fn string, mode os.FileMode) {
 		log.Printf("Failed to read file %q: %s", fn, err)
 		return
 	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("Recovered in processFile while processing %s: %#v\n", fn, r)
+		}
+	}()
 
 	f, diags := hclwrite.ParseConfig(src, fn, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {


### PR DESCRIPTION
This PR aims to work-around the issue described in #2.

Without this change:

```sh
# terraform-clean-syntax .
2019/12/05 11:37:09 Made changes: common/global/dns/variables.tf
2019/12/05 11:37:09 Made changes: common/global/managed-ssl/variables.tf
2019/12/05 11:37:09 Made changes: common/global/variables.tf
2019/12/05 11:37:09 Made changes: common/infra/gcr/variables.tf
2019/12/05 11:37:09 Made changes: common/infra/gcs/variables.tf
2019/12/05 11:37:09 Made changes: common/infra/gke/variables.tf
2019/12/05 11:37:09 Made changes: common/infra/gke-regional/variables.tf
2019/12/05 11:37:09 Made changes: common/infra/net/variables.tf
panic: didn't find any token of type TokenIdent

goroutine 1 [running]:
github.com/hashicorp/hcl/v2/hclwrite.inputTokens.PartitionType(0xc00013ad00, 0x0, 0x0, 0xc0000ae840, 0x0, 0x0, 0xc000000049, 0x0, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:88 +0x580
github.com/hashicorp/hcl/v2/hclwrite.inputTokens.PartitionTypeSingle(0xc00013ad00, 0x0, 0x0, 0xc0000ae840, 0x0, 0x0, 0xc000000049, 0x0, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:92 +0xe3
github.com/hashicorp/hcl/v2/hclwrite.parseTraversalStep(0x709ac0, 0xc0000a1360, 0xc00013ad00, 0x0, 0x0, 0xc0000ae840, 0x0, 0x0, 0xc00013ad00, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:395 +0x364
github.com/hashicorp/hcl/v2/hclwrite.parseTraversal(0xc0002c14c0, 0x2, 0x2, 0xc00013ad00, 0x0, 0x0, 0xc0000ae840, 0x0, 0x0, 0xc00013ad00, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:377 +0x3da
github.com/hashicorp/hcl/v2/hclwrite.parseExpression(0x70b080, 0xc0005c2150, 0xc00013ad00, 0x2, 0x2, 0xc0000ae840, 0x2, 0x2, 0x14)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:356 +0x175
github.com/hashicorp/hcl/v2/hclwrite.parseAttribute(0xc0000bca80, 0xc00013aa00, 0x0, 0x0, 0xc0000ae800, 0x0, 0x0, 0xc00013a8e0, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:260 +0xaf4
github.com/hashicorp/hcl/v2/hclwrite.parseBodyItem(0x7082e0, 0xc0000bca80, 0xc00013a8e0, 0x1d, 0x1d, 0xc0000ae7e8, 0x1d, 0x1d, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:217 +0x632
github.com/hashicorp/hcl/v2/hclwrite.parseBody(0xc0000a86e0, 0xc00013a520, 0x27, 0x27, 0xc0000ae798, 0x27, 0x27, 0x0, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:193 +0x68d
github.com/hashicorp/hcl/v2/hclwrite.parseBlock(0xc0000a46c0, 0xc00013a520, 0x0, 0x0, 0xc0000ae798, 0x0, 0x0, 0xc00013a1c0, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:329 +0xf72
github.com/hashicorp/hcl/v2/hclwrite.parseBodyItem(0x708320, 0xc0000a46c0, 0xc00013a1c0, 0x32, 0x32, 0xc0000ae750, 0x32, 0x32, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:219 +0x4f7
github.com/hashicorp/hcl/v2/hclwrite.parseBody(0xc0000a8790, 0xc000138000, 0x8d, 0x100, 0xc0000ae480, 0x8d, 0x8d, 0x0, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:193 +0x68d
github.com/hashicorp/hcl/v2/hclwrite.parse(0xc0000f8000, 0x2b5, 0x4b5, 0xc00001a480, 0x26, 0x1, 0x1, 0x0, 0xffffffffffffff9c, 0xc00001a4b0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/parser.go:53 +0x2e4
github.com/hashicorp/hcl/v2/hclwrite.ParseConfig(...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.0/hclwrite/public.go:27
main.processFile(0xc00001a480, 0x26, 0x1a4)
        /home/patrick/go/pkg/mod/github.com/apparentlymart/terraform-clean-syntax@v0.0.0-20191204155136-6e9583834134/main.go:78 +0xc8
main.processItem(0xc00001a480, 0x26)
        /home/patrick/go/pkg/mod/github.com/apparentlymart/terraform-clean-syntax@v0.0.0-20191204155136-6e9583834134/main.go:55 +0x2e7
main.processDir(0xc0001c1700, 0x13)
        /home/patrick/go/pkg/mod/github.com/apparentlymart/terraform-clean-syntax@v0.0.0-20191204155136-6e9583834134/main.go:67 +0x119
main.processItem(0xc0001c1700, 0x13)
        /home/patrick/go/pkg/mod/github.com/apparentlymart/terraform-clean-syntax@v0.0.0-20191204155136-6e9583834134/main.go:47 +0x1cc
main.processDir(0xc0004da6d0, 0xc)
        /home/patrick/go/pkg/mod/github.com/apparentlymart/terraform-clean-syntax@v0.0.0-20191204155136-6e9583834134/main.go:67 +0x119
main.processItem(0xc0004da6d0, 0xc)
        /home/patrick/go/pkg/mod/github.com/apparentlymart/terraform-clean-syntax@v0.0.0-20191204155136-6e9583834134/main.go:47 +0x1cc
main.processDir(0xc0000147f0, 0x6)
        /home/patrick/go/pkg/mod/github.com/apparentlymart/terraform-clean-syntax@v0.0.0-20191204155136-6e9583834134/main.go:67 +0x119
main.processItem(0xc0000147f0, 0x6)
        /home/patrick/go/pkg/mod/github.com/apparentlymart/terraform-clean-syntax@v0.0.0-20191204155136-6e9583834134/main.go:47 +0x1cc
main.processDir(0x7ffcd9b66e60, 0x1)
main.main()
        /home/patrick/go/pkg/mod/github.com/apparentlymart/terraform-clean-syntax@v0.0.0-20191204155136-6e9583834134/main.go:30 +0xec
```

With this change:

```sh
# terraform-clean-syntax .
2019/12/05 12:42:53 Made changes: common/global/dns/variables.tf
2019/12/05 12:42:53 Made changes: common/global/managed-ssl/variables.tf
2019/12/05 12:42:53 Made changes: common/global/variables.tf
2019/12/05 12:42:53 Made changes: common/infra/gcr/variables.tf
2019/12/05 12:42:53 Made changes: common/infra/gcs/variables.tf
2019/12/05 12:42:53 Made changes: common/infra/gke/variables.tf
2019/12/05 12:42:53 Made changes: common/infra/gke-regional/variables.tf
2019/12/05 12:42:53 Made changes: common/infra/net/variables.tf
Recovered in processFile while processing common/infra/pubsub/iam_subscribers.tf: "didn't find any token of type TokenIdent"
Recovered in processFile while processing common/infra/pubsub/subscriptions.tf: "didn't find any token of type TokenIdent"
2019/12/05 12:42:53 Made changes: common/infra/pubsub/variables.tf
2019/12/05 12:42:53 Made changes: common/infra/vpn/variables.tf
Recovered in processFile while processing common/k8s/cluster0/monitoring.tf: "didn't find any token of type TokenOBrack"
2019/12/05 12:42:53 Made changes: common/k8s/cluster0/variables.tf
Recovered in processFile while processing common/k8s/cluster1/custom-metrics-stackdriver-adapter.tf: "didn't find any token of type TokenOBrack"
Recovered in processFile while processing common/k8s/cluster1/monitoring.tf: "didn't find any token of type TokenOBrack"
2019/12/05 12:42:53 Made changes: common/k8s/cluster1/variables.tf
Recovered in processFile while processing common/k8s/credentials/outputs.tf: "didn't find any token of type TokenIdent"
2019/12/05 12:42:53 Made changes: common/k8s/credentials/variables.tf
Recovered in processFile while processing common/k8s/monitoring/datadog-daemonset.tf: "didn't find any token of type TokenOBrack"
2019/12/05 12:42:53 Made changes: common/k8s/monitoring/variables.tf
2019/12/05 12:42:53 Made changes: common/k8s/namespaces/variables.tf
2019/12/05 12:42:53 Made changes: common/logging/variables.tf
2019/12/05 12:42:53 Made changes: common/monitoring/datadog/datadog-monitor-template/variables.tf
2019/12/05 12:42:53 Made changes: common/monitoring/datadog/variables.tf
2019/12/05 12:42:53 Made changes: common/myapp/apps/app/variables.tf
2019/12/05 12:42:53 Made changes: common/myapp/apps/iam/variables.tf

[...]
```