### PR TITLE
Recover HCL parsing errors with stack trace

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -78,7 +79,7 @@ func processFile(fn string, mode os.FileMode) {
 
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Printf("Recovered in processFile while processing %s: %#v\n", fn, r)
+			fmt.Printf("Recovered in processFile while processing %s: %#v\n%s", fn, r, debug.Stack())
 		}
 	}()
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -74,6 +75,12 @@ func processFile(fn string, mode os.FileMode) {
 		log.Printf("Failed to read file %q: %s", fn, err)
 		return
 	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("Recovered in processFile while processing %s: %#v\n", fn, r)
+		}
+	}()
 
 	f, diags := hclwrite.ParseConfig(src, fn, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {


### PR DESCRIPTION
Follow up on https://github.com/apparentlymart/terraform-clean-syntax/pull/4#issuecomment-562675073

Sample output:

```
terraform-clean-syntax .
2019/12/07 13:17:54 Made changes: common/global/dns/variables.tf
2019/12/07 13:17:54 Made changes: common/global/managed-ssl/variables.tf
2019/12/07 13:17:54 Made changes: common/global/variables.tf
2019/12/07 13:17:54 Made changes: common/infra/gcr/variables.tf
2019/12/07 13:17:54 Made changes: common/infra/gcs/variables.tf
2019/12/07 13:17:54 Made changes: common/infra/gke/variables.tf
2019/12/07 13:17:54 Made changes: common/infra/gke-regional/variables.tf
2019/12/07 13:17:54 Made changes: common/infra/net/variables.tf
2019/12/07 13:17:54 Made changes: common/infra/pubsub/variables.tf
2019/12/07 13:17:54 Made changes: common/infra/vpn/variables.tf
Recovered in processFile while processing common/k8s/cluster0/monitoring.tf: "didn't find any token of type TokenOBrack"
goroutine 1 [running]:
runtime/debug.Stack(0xc00020a7c0, 0x62e060, 0xc0004ce740)
        /usr/local/go/src/runtime/debug/stack.go:24 +0x9d
main.processFile.func1(0xc00001ad80, 0x21)
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:82 +0x6e
panic(0x62e060, 0xc0004ce740)
        /usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/hashicorp/hcl/v2/hclwrite.inputTokens.PartitionType(0xc00031e020, 0x2, 0x2, 0xc0000b0c58, 0x2, 0x2, 0xc00000005b, 0x0, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:88 +0x580
github.com/hashicorp/hcl/v2/hclwrite.parseTraversalStep(0x7092e0, 0xc000321680, 0xc00031e020, 0x2, 0x2, 0xc0000b0c58, 0x2, 0x2, 0xc00031e020, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:408 +0xdab
github.com/hashicorp/hcl/v2/hclwrite.parseTraversal(0xc0003c1300, 0x5, 0x8, 0xc00031de40, 0x9, 0x9, 0xc0000b0c30, 0x9, 0x9, 0xc00031de40, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:377 +0x3da
github.com/hashicorp/hcl/v2/hclwrite.parseExpression(0x70a920, 0xc0003214a0, 0xc00031de40, 0x9, 0x9, 0xc0000b0c30, 0x9, 0x9, 0x8)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:356 +0x175
github.com/hashicorp/hcl/v2/hclwrite.parseAttribute(0xc00041d180, 0xc00031de40, 0x0, 0x0, 0xc0000b0c30, 0x0, 0x0, 0xc00031dd20, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:260 +0xaf4
github.com/hashicorp/hcl/v2/hclwrite.parseBodyItem(0x707b40, 0xc00041d180, 0xc00031dd20, 0x2d, 0x2d, 0xc0000b0c18, 0x2d, 0x2d, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:217 +0x632
github.com/hashicorp/hcl/v2/hclwrite.parseBody(0xc0000a9080, 0xc00031d1e0, 0x4b, 0x4b, 0xc0000b0b28, 0x4b, 0x4b, 0x0, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:193 +0x68d
github.com/hashicorp/hcl/v2/hclwrite.parseBlock(0xc0000a58c0, 0xc00031d1e0, 0x0, 0x0, 0xc0000b0b28, 0x0, 0x0, 0xc00031d000, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:329 +0xf72
github.com/hashicorp/hcl/v2/hclwrite.parseBodyItem(0x707b80, 0xc0000a58c0, 0xc00031d000, 0x52, 0x52, 0xc0000b0b00, 0x52, 0x52, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:219 +0x4f7
github.com/hashicorp/hcl/v2/hclwrite.parseBody(0xc0000a9130, 0xc00031d000, 0x53, 0x80, 0xc0000b0b00, 0x53, 0x53, 0x0, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:193 +0x68d
github.com/hashicorp/hcl/v2/hclwrite.parse(0xc0000c4400, 0x1fc, 0x3fc, 0xc00001ad80, 0x21, 0x1, 0x1, 0x0, 0x435bd8, 0xc000000180, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:53 +0x2e4
github.com/hashicorp/hcl/v2/hclwrite.ParseConfig(...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/public.go:27
main.processFile(0xc00001ad80, 0x21, 0x1a4)
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:86 +0x132
main.processItem(0xc00001ad80, 0x21)
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:57 +0x2e7
main.processDir(0xc000196f60, 0x13)
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:69 +0x119
main.processItem(0xc000196f60, 0x13)
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:49 +0x1cc
main.processDir(0xc00047b746, 0xa)
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:69 +0x119
main.processItem(0xc00047b746, 0xa)
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:49 +0x1cc
main.processDir(0x7ffd672c9e78, 0x1)
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:69 +0x119
main.processItem(0x7ffd672c9e78, 0x1)
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:49 +0x1cc
main.main()
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:32 +0xec
2019/12/07 13:17:54 Made changes: common/k8s/cluster0/variables.tf
Recovered in processFile while processing common/k8s/cluster1/custom-metrics-stackdriver-adapter.tf: "didn't find any token of type TokenOBrack"
goroutine 1 [running]:
runtime/debug.Stack(0xc00056f750, 0x62e060, 0xc0001ac830)
        /usr/local/go/src/runtime/debug/stack.go:24 +0x9d
main.processFile.func1(0xc00001db80, 0x39)
        /home/patrick/go/src/github.com/apparentlymart/terraform-clean-syntax/main.go:82 +0x6e
panic(0x62e060, 0xc0001ac830)
        /usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/hashicorp/hcl/v2/hclwrite.inputTokens.PartitionType(0xc00017c300, 0x2, 0x2, 0xc000199840, 0x2, 0x2, 0xc00000005b, 0x0, 0x0, 0x0, ...)
        /home/patrick/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.1.1-0.20191206020329-84e71e9393a0/hclwrite/parser.go:88 +0x580
github.com/hashicorp/hcl/v2/hclwrite.parseTraversalStep(0x7092e0, 0xc0000fcf60, 0xc00017c300, 0x2, 0x2, 0xc000199840, 0x2, 0x2, 0xc00017c300, 0x0, ...)
...
```