### PR TITLE
feat: add support for provider meta-arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,6 +216,10 @@ func cleanProviderExpr(tokens hclwrite.Tokens) hclwrite.Tokens {
 		// Not a quoted string sequence, then.
 		return tokens
 	}
+	// HACK: Technically a provider.alias sequence ought to be three
+	// separate tokens, because the dot is an operator, but only the
+	// `Bytes` part of this is relevant to our output anyway so
+	// we'll cheat and thus avoid the need to parse `strTok.Bytes.
 	return hclwrite.Tokens{
 		{
 			Type:  hclsyntax.TokenIdent,


### PR DESCRIPTION
This pull request adds support for removing quoted references for `provider` meta-arguments.

For example, given the following Terraform configuration:

```hcl
provider "aws" {
  alias = "prod"

  region = "us-east-1"
}

variable "owners" {
  default = ["self"]
  type    = "list"
}

provider "null" {
  alias = "foo"
}

resource "null_resource" "cat" {
  provider = "null.foo"
}

data "aws_ami" "example" {
  provider = "aws.prod"

  owners = "${var.owners}"
}
```

Invoking `terraform-clean-syntax` rewrites the file like so:

```hcl
provider "aws" {
  alias = "prod"

  region = "us-east-1"
}

variable "owners" {
  default = ["self"]
  type    = list(string)
}

provider "null" {
  alias = "foo"
}

resource "null_resource" "cat" {
  provider = null.foo
}

data "aws_ami" "example" {
  provider = aws.prod

  owners = var.owners
}
```

Where quotes are removed from the `provider = null.foo` and `provider = aws.prod` meta-arguments.

Fixes #13 